### PR TITLE
use name in the COPY instruction instead of number 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN CGO_ENABLED=0 go build -o app .
 FROM alpine:latest
 MAINTAINER ops@adhocteam.us
 WORKDIR /root/
-COPY --from=0 /go/src/app/app .
+COPY --from=builder /go/src/app/app .
 CMD ["./app"]


### PR DESCRIPTION
This improves the COPY instruction by using the stage name `builder`.
Also means that even if the instructions in Dockerfile are re-ordered
later, the `COPY` won't break.